### PR TITLE
implement delete and list-docs endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,6 +3,7 @@ from flask import Flask, request
 from split import split_text
 from embed_and_store import add_documents
 from summarize import summarize
+from manage_documents import delete_docs, list_docs
 import os
 
 app = Flask(__name__)
@@ -31,6 +32,26 @@ def handle_upload():
 #@app.route('/summarize', methods=['POST'])
  #   def write_this_soon(text):
   #  summary = summarize("This is a test")
+
+@app.route('/list-docs', methods=['POST'])
+def get_chunk_ids():
+    body = request.get_json()
+    doc_id = body.get('doc_id')
+
+    if not doc_id:
+        return { "error": 'Bad request' }, 400
+    
+    return { "ids": list_docs(doc_id) }
+
+@app.route('/delete', methods=['POST'])
+def delete_chunks_by_doc_id():
+    body = request.get_json()
+    doc_id = body.get('doc_id')
+
+    if not doc_id:
+        return { "error": 'Bad request' }, 400
+    
+    return { "success": delete_docs(doc_id) }
 
 
 if __name__ == '__main__':

--- a/manage_documents.py
+++ b/manage_documents.py
@@ -1,0 +1,12 @@
+import chromadb
+
+client = chromadb.PersistentClient(path="/workspaces/KnotebookLM_summary_engine/chroma_langchain_db")
+collection = client.get_collection('knotebooklm')
+
+def list_docs(doc_id):
+    result = collection.get(where={ "document_id": doc_id }, include=[])
+    return result["ids"]
+
+def delete_docs(doc_id):
+    collection.delete(where={ "document_id": doc_id })
+    return True

--- a/requests/delete.py
+++ b/requests/delete.py
@@ -1,0 +1,18 @@
+import requests
+import json
+
+base_url = "http://127.0.0.1:5000" 
+path = "/delete"
+url = base_url + path
+
+data = { "doc_id": "892" }
+headers = {"Content-Type": "application/json"}
+
+response = requests.post(url, data=json.dumps(data), headers=headers)
+
+if response.status_code == 200:
+    print("Request successful!")
+    print(response.json())
+else:
+    print(f"Error: {response.status_code}")
+    print(response.text)

--- a/requests/list-docs.py
+++ b/requests/list-docs.py
@@ -1,0 +1,18 @@
+import requests
+import json
+
+base_url = "http://127.0.0.1:5000" 
+path = "/list-docs"
+url = base_url + path
+
+data = { "doc_id": "892" }
+headers = {"Content-Type": "application/json"}
+
+response = requests.post(url, data=json.dumps(data), headers=headers)
+
+if response.status_code == 200:
+    print("Request successful!")
+    print(response.json())
+else:
+    print(f"Error: {response.status_code}")
+    print(response.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+chromadb==1.0.9
 flask
 gunicorn==23.0.0
 langchain_chroma


### PR DESCRIPTION
Adds new `chromadb` interface and adds the functionality to 
  - get a list of chunk IDs that match a document ID (`/list-docs`)
  - delete all chunks that match a document ID (`/delete`)

# Testing
- Install  new dependency by running `python -m pip install -r requirements.txt`
- In one shell, start the API
- In another shell, 
   - Run `python post.py` to populate a document in the database. Note the `doc_id`.
   - Run `./requests/list-docs.py` making sure to use the same `doc_id`. Confirm that it returns one or more document IDs.
   - Run `./requests/delete.py` making sure to use the same `doc_id`. You should get a success response.
   - Re-run `./requests/list-docs.py` and confirm that the list of `ids` returned is empty.